### PR TITLE
Fix: nbody.pro must specify c++11

### DIFF
--- a/nbody.pro
+++ b/nbody.pro
@@ -7,6 +7,8 @@
 QT       += core gui
 unix: QT += x11extras
 
+CONFIG += c++11
+
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 TARGET = nbody


### PR DESCRIPTION
Since the project uses c++11 features, the project settings should specify appropriate compiler configuration.
